### PR TITLE
Focus trap now respects `returnFocusOnDeactivate`

### DIFF
--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -49,7 +49,10 @@ class FocusTrap extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.active && !this.props.active) {
-      this.focusTrap.deactivate();
+      const { returnFocusOnDeactivate } = this.props.focusTrapOptions;
+      const returnFocus = returnFocusOnDeactivate || false;
+      const config = { returnFocus };
+      this.focusTrap.deactivate(config);
     } else if (!prevProps.active && this.props.active) {
       this.focusTrap.activate();
     }

--- a/test/deactivation.test.js
+++ b/test/deactivation.test.js
@@ -62,6 +62,46 @@ describe('deactivation', () => {
     expect(mockFocusTrap.deactivate).toHaveBeenCalledTimes(1);
   });
 
+  test('deactivation respects `returnFocusOnDeactivate` option', () => {
+    class TestZone extends React.Component {
+      state = {
+        trapActive: true
+      };
+
+      deactivateTrap = () => {
+        this.setState({ trapActive: false });
+      };
+
+      render() {
+        return (
+          <div>
+            <button ref="trigger" onClick={this.deactivateTrap}>
+              deactivate
+            </button>
+            <FocusTrap
+              ref={(component) => this.trap = component}
+              active={this.state.trapActive}
+              focusTrapOptions={{ returnFocusOnDeactivate: true }}
+            >
+              <button>
+                something special
+              </button>
+            </FocusTrap>
+          </div>
+        );
+      }
+    }
+
+    const zone = ReactDOM.render(<TestZone />, domContainer);
+    // mock deactivate on the fouscTrap instance for we can asset 
+    // that we are passing the correct config to the focus trap.
+    zone.trap.focusTrap.deactivate = jest.fn();
+
+    TestUtils.Simulate.click(ReactDOM.findDOMNode(zone.refs.trigger));
+
+    expect(zone.trap.focusTrap.deactivate).toHaveBeenCalledWith({ returnFocus: true });
+  });
+  
   test('deactivation by dismount', () => {
     class TestZone extends React.Component {
       state = {


### PR DESCRIPTION
Focus trap now respect `returnFocusOnDeactivate` flag when the `active` prop is in use.

Previously, the `returnFocusOnDeactivate` was been ignored during the `componentDidUpdate` lifecycle. This commit will ensure that `returnFocus` override is passed into the underlying focus-trap instance, which triggers the `returnFocusOnDeactivate` behaviour.

Issue: https://github.com/davidtheclark/focus-trap-react/issues/32